### PR TITLE
Support twitter recovery

### DIFF
--- a/src/background/message.js
+++ b/src/background/message.js
@@ -246,6 +246,9 @@ function hear(msg) {
                     case path.ismatch("shop_exchange/activate_personal_support"):
                         Time.addJdBuff(msg.data);
                         break;
+                    case path.ismatch("twitter/tweet"):
+                        twitterRecovery(msg.data.json);
+                        break;
                 }
                 // General actions
                 if (/teamraid\d+\//.test(path)) {

--- a/src/background/profile.js
+++ b/src/background/profile.js
@@ -282,3 +282,12 @@ function useRecoveryItem(json) {
     }
     updateUI("updStatus", Profile.status);
 }
+
+function twitterRecovery(json) {
+    // {"result":2,"reward_status":true}
+   if (json.reward_status) {
+        Profile.status.ap.current += Profile.status.ap.max;
+        Profile.status.bp.current += Profile.status.bp.max;
+        updateUI("updStatus", Profile.status);
+    }
+}


### PR DESCRIPTION
Automatically updates the display when user tweets to recover AP/BP.
There are edge cases it cant work where `Profile.status` have not capture any values, but it would not affect the AP/BP as the formula `current += max` would be `0 += 0`

The path will be triggered whenever user tweets e.g. via raid or profile page but we only need to check `reward_status`