### PR TITLE
Support use recovery item

### DIFF
--- a/src/background/message.js
+++ b/src/background/message.js
@@ -158,6 +158,7 @@ function hear(msg) {
                         Profile.update(msg.data.json);
                         break;
                     case path.ismatch("quest/user_item"):
+                    case path.ismatch("item/use_normal_item"):
                         useRecoveryItem(msg.data.json);
                         break;
                     case path.ismatch("rest/raid/start"):

--- a/src/background/profile.js
+++ b/src/background/profile.js
@@ -270,15 +270,21 @@ function updateGuildInfo(json) {
 }
 
 function useRecoveryItem(json) {
-    // "/item/use_normal_item" (supplies page) returns json data without the "result" subkey.
+    // "/item/use_normal_item" (homepage & supplies page) returns json data without the "result" subkey.
     // "/quest/user_item" (popups) have the subkey.
-    // On supplies the game automatically queries user status (/user/status) afterwards so we just let that set it instead.
-    if (json.result.recovery_str == "AP") {
-        Profile.status.ap.current = json.result.after;
+    // On supplies the game automatically queries user status (/user/status) but in homepage does not
+    // Proactively update the status instead of depending on side effects of (/user/status)
+
+    let recoveryObj = (json.result) ? json.result : json;
+
+    // {"recovery":"1","before":15,"after":90,"recovery_str":"AP","use_flag":true}
+    // {"recovery":"2","before":6,"after":7,"recovery_str":"EP","use_flag":true}
+    if (recoveryObj.recovery_str == "AP") {
+        Profile.status.ap.current = recoveryObj.after;
     }
     // It literally uses BP everywhere except here...
-    else if (json.result.recovery_str == "EP") {
-        Profile.status.bp.current = json.result.after;
+    else if (recoveryObj.recovery_str == "EP") {
+        Profile.status.bp.current = recoveryObj.after;
     }
     updateUI("updStatus", Profile.status);
 }


### PR DESCRIPTION
The main purpose is to support the AP/BP recovery item usage in the homepage (clicking the AP/BP gauge). Soon cygames will also implement the same feature in other pages.

The Homepage recovery shares the same endpoint as Supplies `/item/use_normal_item`. however, the existing code assumes it `/user/status` will be called next which is not the case for homepage. Code changes to proactively update the AP/BP.

**Reference**

Homepage popup recovery (`/item/use_normal_item`) 
```
{recovery: "1", before: 98, after: 173, recovery_str: "AP", use_flag: true}
{recovery: "2", before: 1, after: 2, recovery_str: "EP", use_flag: true}
```
  
  
Supplies (`/item/use_normal_item` and then calls `/user/status`)
```
{recovery: "1", before: 173, after: 248, recovery_str: "AP", use_flag: true}
{recovery: "2", before: 2, after: 3, recovery_str: "EP", use_flag: true}
```
  
  
Start/Join raid popup refill (`/quest/user_item`)
```
{success: true, duplicate_key: 1, result: {recovery: "1", before: 68, after: 143, recovery_str: "AP", use_flag: true}
{success: true, duplicate_key: 1, result: {recovery: "2", before: 0, after: 3, recovery_str: "EP", use_flag: true}}
```