### PR TITLE
Manually update raid list on AP changes

### DIFF
--- a/src/background/profile.js
+++ b/src/background/profile.js
@@ -281,6 +281,7 @@ function useRecoveryItem(json) {
         Profile.status.bp.current = json.result.after;
     }
     updateUI("updStatus", Profile.status);
+    updateUI("updRaid", Raids.getList());
 }
 
 function twitterRecovery(json) {
@@ -289,5 +290,6 @@ function twitterRecovery(json) {
         Profile.status.ap.current += Profile.status.ap.max;
         Profile.status.bp.current += Profile.status.bp.max;
         updateUI("updStatus", Profile.status);
-    }
+        updateUI("updRaid", Raids.getList());
+   }
 }


### PR DESCRIPTION
The existing code only updates the Raid list when it captures a full User Status object. In the `useRecoveryItem` and `twitterRecovery`, the code directly manipulates the value of AP/BP, thus causing the Raid list still displays red bar (indicate not enough AP)